### PR TITLE
fix: Fix error fd 3 is not a socket on macos

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -116,7 +116,7 @@ pub fn execute() -> Result<(), Error> {
 
     if !quiet {
         for &(ref fd, raw_fd) in &raw_fds {
-            log!("socket {}", fd.describe_raw_fd(raw_fd)?);
+            log!("socket {} -> fd #{}", fd.describe_raw_fd(raw_fd)?, raw_fd);
         }
     }
 

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -16,6 +16,8 @@ mod imp {
 
         if !raw_fds.is_empty() {
             cmd.env("LISTEN_FDS", raw_fds.len().to_string());
+            let (_, rawfd) = raw_fds.first().unwrap();
+            cmd.env("LISTEN_FDS_FIRST_FD", rawfd.to_string());
             if !no_pid {
                 cmd.env("LISTEN_PID", getpid().to_string());
             }


### PR DESCRIPTION
When running on macos, if you have any command that opens file descriptors before systemfd, the following error would happen

```
fd 3 is not a socket
```

One example is `make -j 2 target` as it opens files for its own usage.

This fixes it by creating a variable pointing to the first fd created so listenfd can start from there, instead of the fixed value of 3.

This should fix #13 and #4 