### PR TITLE
Add configuration for socket listen queue size

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,6 +1,6 @@
 name: Clippy
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,6 +1,6 @@
 name: Rustfmt
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test-latest:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,6 +50,19 @@ fn make_app() -> Command {
                 ),
         )
         .arg(
+            Arg::new("backlog")
+                .short('b')
+                .long("backlog")
+                .default_value("1")
+                .value_parser(value_parser!(i32).range(1..))
+                .value_name("LISTEN-QUEUE")
+                .help(
+                    "The length of the socket backlog queue in any listen call which \
+                     must be a positive integer greater than or equal to 1.  The OS may \
+                     silently cap this value to a lower setting.",
+                ),
+        )
+        .arg(
             Arg::new("no_pid")
                 .long("no-pid")
                 .action(ArgAction::SetTrue)
@@ -57,7 +70,7 @@ fn make_app() -> Command {
                     "When this is set the LISTEN_PID environment variable is not \
              emitted.  This is supported by some systems such as the listenfd \
              crate to skip the pid check.  This is necessary for proxying \
-             through to other processe like cargo-watch which would break \
+             through to other processes like cargo-watch which would break \
              the pid check.  This has no effect on windows.",
                 ),
         )
@@ -120,7 +133,7 @@ pub fn execute() -> Result<(), Error> {
         log!("warning: no sockets created");
     } else {
         for fd in fds {
-            let raw_fd = fd.create_raw_fd()?;
+            let raw_fd = fd.create_raw_fd(*matches.get_one("backlog").expect("default value"))?;
             raw_fds.push((fd, raw_fd));
         }
     }

--- a/src/fd.rs
+++ b/src/fd.rs
@@ -233,7 +233,6 @@ mod imp {
     use std::os::windows::io::{FromRawSocket, IntoRawSocket};
 
     use anyhow::{bail, Error};
-    use libc::c_int;
 
     pub fn create_raw_fd(fd: &Fd, listen_backlog: i32) -> Result<RawFd, Error> {
         let (addr, dom, ty) = sock_info(fd)?;
@@ -241,7 +240,7 @@ mod imp {
 
         sock.bind(&addr)?;
         if fd.should_listen() {
-            sock.listen(listen_backlog as c_int)?;
+            sock.listen(listen_backlog as _)?;
         }
 
         Ok(sock.into_raw_socket())


### PR DESCRIPTION
Systemd allows setting the backlog for socket services with the 'Backlog' parameter. This helps to support services where the connection rate is high.

systemfd uses a backlog length of 1, and provides no way to configure this. Although this utility is intended primarily for testing, there may still be cases where setting this is useful (for instance when running performance tests). To support this, this change adds a 'backlog' parameter, with short code 'b'. The default value for this parameter is 1, which maintains the existing behaviour.

In cases where multiple listening sockets are specified, the same backlog value is applied to every socket.