### PR TITLE
Restore multiple socket support after clap upgrade

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,8 +33,7 @@ fn make_app() -> Command {
             Arg::new("socket")
                 .short('s')
                 .long("socket")
-                .num_args(1..)
-                .number_of_values(1)
+                .action(ArgAction::Append)
                 .value_name("TYPE::SPEC")
                 .help(
                     "This parameter can be supplied multiple times.  Each time it's \


### PR DESCRIPTION
Another impact of the update to clap is that the support for multiple copies of a parameter has changed. This means that it is currently not possible to specify multiple listening sockets.

Clap has added a feature which allows a single parameter to take multiple values, for instance `-s 2000 3000` would create two listening TCP sockets. This behaviour is enabled with the `Arg::num_args` function when given a range.

Related to this, the `Arg::number_of_values` function is now a call to `Arg::num_args` with a single value (and as a result is deprecated).

The combination of these two factors means that the current code is first setting a range, and then overriding this with a unit value.

One option would therefore be to remove line 37 (`.number_of_values(1)`) although this would then need to update documentation and usages.

To restore the previous behaviour it is necessary to add a call to `Arg::action`, specifying to append parameters into a list. The calls to `num_args` and `number_of_values` can then be removed as the number defaults to a single value per option.